### PR TITLE
ECO-443 python3.8 support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,4 +21,4 @@ flake8 = "*"
 protobuf = "==3.12.2"
 
 [requires]
-python_version = "3.7"
+python_version = ">=3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba9550b75c1c49caf079b2e4044dcc1273e9ed2c8ccde1745950ada7ae2e9a30"
+            "sha256": "12340464e78f47079f6068ff209b84abb6820b7916a637d7ed47b5e4af211ef0"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": ">=3.7"
         },
         "sources": [
             {
@@ -99,9 +99,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
+                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "ecdsa": {
             "hashes": [
@@ -244,11 +245,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
-                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.1"
+            "version": "==1.7.0"
         },
         "in-place": {
             "hashes": [
@@ -436,11 +437,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e",
-                "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"
+                "sha256:a0d36849e59ac4a28664e80951a634b0e920d88047ce3fa8fa7b45216e573f30",
+                "sha256:db12b48359ba2cbc8c8f7ab712706ee67d59f8f9e8e0c795dcc45349b8784e48"
             ],
             "index": "pypi",
-            "version": "==3.15.2"
+            "version": "==3.16.0"
         },
         "virtualenv": {
             "hashes": [

--- a/casperlabs_client/commands/common_options.py
+++ b/casperlabs_client/commands/common_options.py
@@ -4,7 +4,7 @@ from casperlabs_client.consts import SUPPORTED_KEY_ALGORITHMS, ED25519_KEY_ALGOR
 from casperlabs_client.arg_types import algorithm, directory_for_write, positive_integer
 
 ALGORITHM_OPTION = [
-    ("-a", "--algorithm"),
+    ("--algorithm",),
     dict(
         required=False,
         type=algorithm,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+grpcio >= 1.20
+grpclib == 0.3.1
+pyblake2 ==1.1.2
+cryptography ==2.8
+grpcio-tools >=1.20
+pytest >= 4.4
+in-place >= 0.4.0
+grpc-tools == 0.0.1
+tox
+pre-commit
+ecdsa ==0.15
+flake8
+protobuf ==3.12.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,3 @@
-[options]
-install_requires =
-     protobuf==3.11.3
-     grpcio>=1.20
-     grpclib==0.3.1
-     pyblake2==1.1.2
-     cryptography==2.8
-     ecdsa==0.15
-     pycryptodome==3.9.4
-
 [metadata]
 license_file = LICENSE.txt
 

--- a/setup.py
+++ b/setup.py
@@ -216,13 +216,13 @@ setup(
     version=read_version(),
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
-        "protobuf==3.11.3",
+        "protobuf==3.12.2",
         "grpcio-tools>=1.20",
         "in-place==0.4.0",
         "grpcio>=1.20",
     ],
     install_requires=[
-        "protobuf==3.11.3",
+        "protobuf==3.12.2",
         "grpcio>=1.20",
         "grpclib==0.3.1",
         "pyblake2==1.1.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py37,py38
+
+[testenv]
+deps = pytest
+commands = pytest tests


### PR DESCRIPTION
Updating protobuf and restructuring requirements for Python 3.8 support.
Added tox for running tests with both Python 3.7 and Python 3.8.

https://casperlabs.atlassian.net/browse/ECO-443