### PR TITLE
NO-TICK Completely eliminating tests from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-exclude tests *

--- a/build.sh
+++ b/build.sh
@@ -7,5 +7,6 @@ cd ${DIR}
 
 rm -rf dist/*
 
-pipenv sync
+# Does same as sync, but aborts if Pipfile and Pipfile.lock are not in sync.
+pipenv install --deploy
 pipenv run python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -105,8 +105,6 @@ def run_protoc(file_names, proto_dir=PROTO_DIR):
 
 
 def collect_proto_files():
-    import grpc_tools
-
     print("Collect files...")
 
     for file_name in Path(PROTOBUF_DIR).glob("**/*.proto"):
@@ -177,9 +175,8 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    # Version now defined in VERSION file in casperlabs_client directory.
     version=read_version(),
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(),
     setup_requires=[
         "protobuf==3.12.2",
         "grpcio-tools>=1.20",


### PR DESCRIPTION
Added MANIFEST.in file to exclude tests as find_package(exclude=[]) fails past a single directory level in tests.