### PR TITLE
ECO-602 Fixing Certificate generation issues with client-py.

### DIFF
--- a/casperlabs_client/casperlabs_client.py
+++ b/casperlabs_client/casperlabs_client.py
@@ -939,10 +939,10 @@ class CasperLabsClient:
         key_pair.save_hex_base64_files(directory, consts.VALIDATOR_FILENAME_PREFIX)
 
         private_key, public_key = crypto.generate_secp256r1_key_pair()
-        node_cert, key_pem = crypto.generate_node_certificates(private_key, public_key)
+        cert_pem, key_pem = crypto.generate_node_certificates(private_key, public_key)
 
         io.write_binary_file(node_private_path, key_pem)
-        io.write_binary_file(node_cert_path, node_cert)
+        io.write_binary_file(node_cert_path, cert_pem)
         io.write_file(node_id_path, crypto.node_public_address(public_key))
 
     @api


### PR DESCRIPTION
Certificates in the Python client were very basic and did not match data and extensions included with certificates generated with the key-generator docker.  This does not include automated CI tests for this, which I will try to add as part of ECO-588 tests.

Both now match in structure when using `openssl x509 -in node.certificate.pem -text -noout`.

A manual test was done by replacing `.casperlabs/nodes/node-0` with client-py generated files and updating `.casperlabs/chainspec/genesis/accounts.csv` with new public key hex (`validator-pk-hex`).  All node started up and synchronized properly.

https://casperlabs.atlassian.net/browse/ECO-602