### PR TITLE
NO-TICK Shortening bors timeout to 30 minutes.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -8,7 +8,7 @@ status = [
 required_approvals = 1
 
 # Number of seconds from when a merge commit is created to when its statuses must pass.
-timeout_sec = 10800 #3h
+timeout_sec = 1800  # 30 minutes
 
 # A marker in the PR description that indicates boilerplate that does not belong in the merge-commit message.
 cut_body_after = "## Overview"


### PR DESCRIPTION
Shortening the bors timeout to 30 minutes from 3 hours and testing drone security fixes with this merge.
